### PR TITLE
[Ios2 92] Base response return, 공통 항목 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-annotations'
 	implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.9.0'
 
+	implementation 'com.google.guava:guava:28.2-jre'
+	implementation 'org.apache.commons:commons-lang3:3.9'
+
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'	

--- a/src/main/java/com/yapp/ios2/fitfty/domain/AbstractEntity.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/AbstractEntity.java
@@ -1,0 +1,22 @@
+package com.yapp.ios2.fitfty.domain;
+
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.ZonedDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AbstractEntity {
+
+    @CreationTimestamp
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    private ZonedDateTime updatedAt;
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/interceptor/CommonHttpRequestInterceptor.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/interceptor/CommonHttpRequestInterceptor.java
@@ -1,0 +1,29 @@
+package com.yapp.ios2.fitfty.global.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class CommonHttpRequestInterceptor extends HandlerInterceptorAdapter {
+
+    public static final String HEADER_REQUEST_UUID_KEY = "x-request-id";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String requestEventId = request.getHeader(HEADER_REQUEST_UUID_KEY);
+        if (StringUtils.isEmpty(requestEventId)) {
+            requestEventId = UUID.randomUUID().toString();
+        }
+
+        MDC.put(HEADER_REQUEST_UUID_KEY, requestEventId);
+        return true;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/response/CommonControllerAdvice.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/response/CommonControllerAdvice.java
@@ -1,0 +1,101 @@
+package com.yapp.ios2.fitfty.global.response;
+
+import com.yapp.ios2.fitfty.global.exception.BaseException;
+import com.yapp.ios2.fitfty.global.interceptor.CommonHttpRequestInterceptor;
+import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
+import org.slf4j.MDC;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+
+@Slf4j
+@ControllerAdvice
+public class CommonControllerAdvice {
+
+    private static final List<ErrorCode> SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST = Lists.newArrayList();
+
+    /**
+     * http status: 500 AND result: FAIL
+     * 시스템 예외 상황. 집중 모니터링 대상
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(value = Exception.class)
+    public CommonResponse onException(Exception e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        log.error("eventId = {} ", eventId, e);
+        return CommonResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR);
+    }
+
+    /**
+     * http status: 200 AND result: FAIL
+     * 시스템은 이슈 없고, 비즈니스 로직 처리에서 에러가 발생함
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(value = BaseException.class)
+    public CommonResponse onBaseException(BaseException e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        if (SPECIFIC_ALERT_TARGET_ERROR_CODE_LIST.contains(e.getErrorCode())) {
+            log.error("[BaseException] eventId = {}, cause = {}, errorMsg = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e), NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        } else {
+            log.warn("[BaseException] eventId = {}, cause = {}, errorMsg = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e), NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        }
+        return CommonResponse.fail(e.getMessage(), e.getErrorCode().name());
+    }
+
+    /**
+     * 예상치 않은 Exception 중에서 모니터링 skip 이 가능한 Exception 을 처리할 때
+     * ex) ClientAbortException
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(value = {ClientAbortException.class})
+    public CommonResponse skipException(Exception e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        log.warn("[skipException] eventId = {}, cause = {}, errorMsg = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e), NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        return CommonResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR);
+    }
+
+    /**
+     * http status: 400 AND result: FAIL
+     * request parameter 에러
+     *
+     * @param e
+     * @return
+     */
+    @ResponseBody
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public CommonResponse methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
+        log.warn("[BaseException] eventId = {}, errorMsg = {}", eventId, NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+        BindingResult bindingResult = e.getBindingResult();
+        FieldError fe = bindingResult.getFieldError();
+        if (fe != null) {
+            String message = "Request Error" + " " + fe.getField() + "=" + fe.getRejectedValue() + " (" + fe.getDefaultMessage() + ")";
+            return CommonResponse.fail(message, ErrorCode.COMMON_INVALID_PARAMETER.name());
+        } else {
+            return CommonResponse.fail(ErrorCode.COMMON_INVALID_PARAMETER.getErrorMsg(), ErrorCode.COMMON_INVALID_PARAMETER.name());
+        }
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/response/CommonResponse.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/response/CommonResponse.java
@@ -1,0 +1,49 @@
+package com.yapp.ios2.fitfty.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> {
+    private Result result;
+    private T data;
+    private String message;
+    private String errorCode;
+
+    public static <T> CommonResponse<T> success(T data, String message) {
+        return (CommonResponse<T>) CommonResponse.builder()
+                .result(Result.SUCCESS)
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+    public static <T> CommonResponse<T> success(T data) {
+        return success(data, null);
+    }
+
+    public static CommonResponse fail(String message, String errorCode) {
+        return CommonResponse.builder()
+                .result(Result.FAIL)
+                .message(message)
+                .errorCode(errorCode)
+                .build();
+    }
+
+    public static CommonResponse fail(ErrorCode errorCode) {
+        return CommonResponse.builder()
+                .result(Result.FAIL)
+                .message(errorCode.getErrorMsg())
+                .errorCode(errorCode.name())
+                .build();
+    }
+
+    public enum Result {
+        SUCCESS, FAIL
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/util/Constants.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/util/Constants.java
@@ -1,0 +1,5 @@
+package com.yapp.ios2.fitfty.global.util;
+
+public class Constants {
+    public final static String API_PREFIX = "api/v1";
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/util/TokenGenerator.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/util/TokenGenerator.java
@@ -1,0 +1,15 @@
+package com.yapp.ios2.fitfty.global.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class TokenGenerator {
+    private static final int TOKEN_LENGTH = 20;
+
+    public static String randomCharacter(int length) {
+        return RandomStringUtils.randomAlphanumeric(length);
+    }
+
+    public static String randomCharacterWithPrefix(String prefix) {
+        return prefix + randomCharacter(TOKEN_LENGTH - prefix.length());
+    }
+}


### PR DESCRIPTION
### 📙 작업 내역

- [x] guava, lang3 dependency 추가
- [x] api prefix `api/v1` 상수 선언을 위한 Constants 파일 추가
- [x] Abstract Entity 생성
- [x] TokenGenerator 생성
- [x] CommonControllerAdvice, HttpRequestInterceptor 추가


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📝 리뷰 노트

앞의 pr에서 언급했던 HttpRequestInterceptor 가 리스폰스 설정 및 에러 핸들링 시 필요했던 내용이라 파일 추가했습니다!
