### PR TITLE
[Ios2 107] board 생성, 조회, 삭제 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-annotations'
 	implementation group: 'org.apache.commons', name: 'commons-dbcp2', version: '2.9.0'
 
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+	annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
+	annotationProcessor(
+			'org.projectlombok:lombok',
+			'org.projectlombok:lombok-mapstruct-binding:0.1.0'
+	)
+
 	implementation 'com.google.guava:guava:28.2-jre'
 	implementation 'org.apache.commons:commons-lang3:3.9'
 

--- a/src/main/java/com/yapp/ios2/fitfty/application/board/BoardFacade.java
+++ b/src/main/java/com/yapp/ios2/fitfty/application/board/BoardFacade.java
@@ -1,4 +1,0 @@
-package com.yapp.ios2.fitfty.application.board;
-
-public class BoardFacade {
-}

--- a/src/main/java/com/yapp/ios2/fitfty/application/picture/PictureFacade.java
+++ b/src/main/java/com/yapp/ios2/fitfty/application/picture/PictureFacade.java
@@ -1,4 +1,21 @@
 package com.yapp.ios2.fitfty.application.picture;
 
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import com.yapp.ios2.fitfty.domain.picture.PictureCommand;
+import com.yapp.ios2.fitfty.domain.picture.PictureService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class PictureFacade {
+    private final PictureService pictureService;
+
+    public Board registerBoard(PictureCommand.RegisterBoardRequest request) {
+        var board = pictureService.registerBoard(request);
+        return board;
+    }
+
 }

--- a/src/main/java/com/yapp/ios2/fitfty/application/tag/TagFacade.java
+++ b/src/main/java/com/yapp/ios2/fitfty/application/tag/TagFacade.java
@@ -1,0 +1,4 @@
+package com.yapp.ios2.fitfty.application.tag;
+
+public class TagFacade {
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
@@ -2,13 +2,16 @@ package com.yapp.ios2.fitfty.domain.picture;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
+import com.yapp.ios2.fitfty.global.util.BooleanToYNConverter;
 import com.yapp.ios2.fitfty.global.util.TokenGenerator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -26,7 +29,7 @@ import java.time.ZonedDateTime;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "board")
+@Table(name = "`board`")
 public class Board extends AbstractEntity {
     private static final String BOARD_PREFIX = "brd_";
 
@@ -34,7 +37,7 @@ public class Board extends AbstractEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String boardToken;
-    private Long userId;
+    private String userToken;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "picture_id")
@@ -49,24 +52,28 @@ public class Board extends AbstractEntity {
     private WeatherType weather;
     private ZonedDateTime photoTakenTime; //data 형식 변경 여부 확인
 
+    @Convert(converter = BooleanToYNConverter.class)
+    private boolean status;
+
     @Builder
-    public Board(Long userId, Picture picture, String content, String location,
+    public Board(String userToken, Picture picture, String content, String location,
                  Float temperature, WeatherType weather, ZonedDateTime photoTakenTime) {
-        if (userId == null) {
-            throw new InvalidParamException("Board.userId");
+        if (StringUtils.isBlank(userToken)) {
+            throw new InvalidParamException("Board.userToken");
         }
         if (picture == null) {
             throw new InvalidParamException("Board.picture");
         }
 
         this.boardToken = TokenGenerator.randomCharacterWithPrefix(BOARD_PREFIX);
-        this.userId = userId;
+        this.userToken = userToken;
         this.picture = picture;
         this.content = content;
         this.location = location;
         this.temperature = temperature;
         this.weather = weather;
         this.photoTakenTime = photoTakenTime;
+        this.status = true;
     }
 
     public void changePicture(Picture picture) {
@@ -91,6 +98,10 @@ public class Board extends AbstractEntity {
 
     public void changePhotoTakenTime(ZonedDateTime photoTakenTime) {
         this.photoTakenTime = photoTakenTime;
+    }
+
+    public void deleteBoard() {
+        this.status = false;
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
@@ -1,4 +1,4 @@
-package com.yapp.ios2.fitfty.domain.board;
+package com.yapp.ios2.fitfty.domain.picture;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Board.java
@@ -1,6 +1,105 @@
 package com.yapp.ios2.fitfty.domain.picture;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
+import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
+import com.yapp.ios2.fitfty.global.util.TokenGenerator;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "board")
 public class Board extends AbstractEntity {
+    private static final String BOARD_PREFIX = "brd_";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String boardToken;
+    private Long userId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "picture_id")
+    private Picture picture;
+
+    @Lob
+    private String content;
+    private String location;
+    private Float temperature;
+
+    @Enumerated(EnumType.STRING)
+    private WeatherType weather;
+    private ZonedDateTime photoTakenTime; //data 형식 변경 여부 확인
+
+    @Builder
+    public Board(Long userId, Picture picture, String content, String location,
+                 Float temperature, WeatherType weather, ZonedDateTime photoTakenTime) {
+        if (userId == null) {
+            throw new InvalidParamException("Board.userId");
+        }
+        if (picture == null) {
+            throw new InvalidParamException("Board.picture");
+        }
+
+        this.boardToken = TokenGenerator.randomCharacterWithPrefix(BOARD_PREFIX);
+        this.userId = userId;
+        this.picture = picture;
+        this.content = content;
+        this.location = location;
+        this.temperature = temperature;
+        this.weather = weather;
+        this.photoTakenTime = photoTakenTime;
+    }
+
+    public void changePicture(Picture picture) {
+        this.picture = picture;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+
+    public void changeLocation(String location) {
+        this.location = location;
+    }
+
+    public void changeTemperature(Float temperature) {
+        this.temperature = temperature;
+    }
+
+    public void changeWeatherType(WeatherType weather) {
+        this.weather = weather;
+    }
+
+    public void changePhotoTakenTime(ZonedDateTime photoTakenTime) {
+        this.photoTakenTime = photoTakenTime;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum WeatherType {
+        SUNNY("맑음"),
+        CLOUDY("구름많음"),
+        GRAY("흐림");
+        private final String description;
+    }
+
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfo.java
@@ -1,0 +1,52 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class BoardInfo {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class Main {
+        private final Long boardId;
+        private final String boardToken;
+        private final Long userId;
+        private final Picture picture;
+        private final String content;
+        private final String location;
+        private final Float temperature;
+        private final Board.WeatherType weather;
+        private final ZonedDateTime photoTakenTime;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class PictureInfo {
+        private final String pictureToken;
+        private final Long userId;
+        private final String filePath;
+        private final Integer bookmarkCnt;
+        private final List<TagGroupInfo> tagGroupList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class TagGroupInfo {
+        private final String tagGroupName;
+        private final List<TagInfo> tagList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class TagInfo {
+        private final String tagValue;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfo.java
@@ -15,8 +15,8 @@ public class BoardInfo {
     public static class Main {
         private final Long boardId;
         private final String boardToken;
-        private final Long userId;
-        private final Picture picture;
+        private final String userToken;
+        private String filePath;
         private final String content;
         private final String location;
         private final Float temperature;
@@ -29,7 +29,7 @@ public class BoardInfo {
     @ToString
     public static class PictureInfo {
         private final String pictureToken;
-        private final Long userId;
+        private final String userToken;
         private final String filePath;
         private final Integer bookmarkCnt;
         private final List<TagGroupInfo> tagGroupList;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfoMapper.java
@@ -16,7 +16,7 @@ import org.mapstruct.ReportingPolicy;
 public interface BoardInfoMapper {
     @Mappings({
             @Mapping(source = "board.id", target = "boardId"),
-            @Mapping(source = "board.picture", target = "picture"),
+            @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath")
     })
     BoardInfo.Main of(Board board);
 

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardInfoMapper.java
@@ -1,0 +1,28 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+import com.yapp.ios2.fitfty.domain.tag.Tag;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface BoardInfoMapper {
+    @Mappings({
+            @Mapping(source = "board.id", target = "boardId"),
+            @Mapping(source = "board.picture", target = "picture"),
+    })
+    BoardInfo.Main of(Board board);
+
+    BoardInfo.PictureInfo of(Picture picture);
+
+    BoardInfo.TagGroupInfo of(TagGroup tagGroup);
+
+    BoardInfo.TagInfo of(Tag tag);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardReader.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardReader.java
@@ -1,0 +1,5 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+public interface BoardReader {
+    Board getBoard(String boardToken);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardStore.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/BoardStore.java
@@ -1,0 +1,6 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+public interface BoardStore {
+    Board store(Board board);
+    Picture pictureStore(Picture picture);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
@@ -3,9 +3,13 @@ package com.yapp.ios2.fitfty.domain.picture;
 import com.google.common.collect.Lists;
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
+import com.yapp.ios2.fitfty.global.util.TokenGenerator;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -21,7 +25,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "pictures")
+@Table(name = "picture")
 public class Picture extends AbstractEntity {
     private static final String ITEM_PREFIX = "pic_";
 
@@ -30,10 +34,29 @@ public class Picture extends AbstractEntity {
     private Long id;
     private String pictureToken;
     private Long userId;
-    private Long boardId;
     private String filePath;
+    private Integer bookmarkCnt;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "picture", cascade = CascadeType.PERSIST)
     private List<TagGroup> tagGroupList = Lists.newArrayList();
+
+    @Builder
+    public Picture(Long userId, String filePath) {
+        if (userId == null) {
+            throw new InvalidParamException("Picture.userId");
+        }
+        if (StringUtils.isBlank(filePath)) {
+            throw new InvalidParamException("Picture.filePath");
+        }
+
+        this.pictureToken = TokenGenerator.randomCharacterWithPrefix(ITEM_PREFIX);
+        this.userId = userId;
+        this.filePath = filePath;
+        this.bookmarkCnt = 0;
+    }
+
+    public void increaseBookmarkCnt() {
+        this.bookmarkCnt += 1;
+    }
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
@@ -2,7 +2,7 @@ package com.yapp.ios2.fitfty.domain.picture;
 
 import com.google.common.collect.Lists;
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
-import com.yapp.ios2.fitfty.domain.picture.taggroup.TagGroup;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/Picture.java
@@ -25,7 +25,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "picture")
+@Table(name = "`picture`")
 public class Picture extends AbstractEntity {
     private static final String ITEM_PREFIX = "pic_";
 
@@ -33,7 +33,7 @@ public class Picture extends AbstractEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String pictureToken;
-    private Long userId;
+    private String userToken;
     private String filePath;
     private Integer bookmarkCnt;
 
@@ -41,8 +41,8 @@ public class Picture extends AbstractEntity {
     private List<TagGroup> tagGroupList = Lists.newArrayList();
 
     @Builder
-    public Picture(Long userId, String filePath) {
-        if (userId == null) {
+    public Picture(String userToken, String filePath) {
+        if (StringUtils.isBlank(userToken)) {
             throw new InvalidParamException("Picture.userId");
         }
         if (StringUtils.isBlank(filePath)) {
@@ -50,7 +50,7 @@ public class Picture extends AbstractEntity {
         }
 
         this.pictureToken = TokenGenerator.randomCharacterWithPrefix(ITEM_PREFIX);
-        this.userId = userId;
+        this.userToken = userToken;
         this.filePath = filePath;
         this.bookmarkCnt = 0;
     }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureCommand.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureCommand.java
@@ -1,0 +1,76 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+import com.yapp.ios2.fitfty.domain.tag.Tag;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.picture.Board.WeatherType;
+import com.yapp.ios2.fitfty.interfaces.picture.BoardDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class PictureCommand {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterBoardRequest {
+        private final String filePath;
+        private final String content;
+        private final Float temperature;
+        private final String location;
+        private final WeatherType weather;
+        private final ZonedDateTime photoTakenTime;
+        private final List<RegisterTagGroupRequest> registerTagGroupRequestList; //ex) 날씨, 스타일
+
+        public Board toEntity(Long userId, Picture picture) {
+            return Board.builder()
+                    .userId(userId)
+                    .picture(picture)
+                    .content(content)
+                    .location(location)
+                    .temperature(temperature)
+                    .weather(weather)
+                    .photoTakenTime(photoTakenTime)
+                    .build();
+        }
+
+        public Picture toPictureEntity(Long userId) {
+            return Picture.builder()
+                    .userId(userId)
+                    .filePath(filePath)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterTagGroupRequest {  // ex) style
+        private final String tagGroupName;
+        private final List<RegisterTagRequest> registerTagRequestList; // ex) formal, casual
+
+        public TagGroup toEntity(Picture picture) {
+            return TagGroup.builder()
+                    .picture(picture)
+                    .tagGroupName(tagGroupName)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterTagRequest {
+        private final String tagValue;
+
+        public Tag toEntity(TagGroup tagGroup) {
+            return Tag.builder()
+                    .tagGroup(tagGroup)
+                    .tagValue(tagValue)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureCommand.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureCommand.java
@@ -25,9 +25,9 @@ public class PictureCommand {
         private final ZonedDateTime photoTakenTime;
         private final List<RegisterTagGroupRequest> registerTagGroupRequestList; //ex) 날씨, 스타일
 
-        public Board toEntity(Long userId, Picture picture) {
+        public Board toEntity(String userToken, Picture picture) {
             return Board.builder()
-                    .userId(userId)
+                    .userToken(userToken)
                     .picture(picture)
                     .content(content)
                     .location(location)
@@ -37,9 +37,9 @@ public class PictureCommand {
                     .build();
         }
 
-        public Picture toPictureEntity(Long userId) {
+        public Picture toPictureEntity(String userToken) {
             return Picture.builder()
-                    .userId(userId)
+                    .userToken(userToken)
                     .filePath(filePath)
                     .build();
         }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureSeriesFactory.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureSeriesFactory.java
@@ -1,0 +1,5 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+public interface PictureSeriesFactory {
+    Picture store(PictureCommand.RegisterBoardRequest request);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureSeriesFactory.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureSeriesFactory.java
@@ -1,5 +1,5 @@
 package com.yapp.ios2.fitfty.domain.picture;
 
 public interface PictureSeriesFactory {
-    Picture store(PictureCommand.RegisterBoardRequest request);
+    Picture store(PictureCommand.RegisterBoardRequest request, String userToken);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureService.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureService.java
@@ -2,7 +2,10 @@ package com.yapp.ios2.fitfty.domain.picture;
 
 public interface PictureService {
     Board registerBoard(PictureCommand.RegisterBoardRequest request);
-//    void changeTag(PictureCommand.ChangeTagRequest request, String userToken);
+
+    void deleteBoard(String boardToken);
+
+    //    void changeTag(PictureCommand.ChangeTagRequest request, String userToken);
 //    void changeBoardInfo(PictureCommand.ChangeBoardInfo request, String userToken);
     BoardInfo.Main retrieveBoardInfo(String boardToken);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureService.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureService.java
@@ -1,0 +1,8 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+public interface PictureService {
+    Board registerBoard(PictureCommand.RegisterBoardRequest request);
+//    void changeTag(PictureCommand.ChangeTagRequest request, String userToken);
+//    void changeBoardInfo(PictureCommand.ChangeBoardInfo request, String userToken);
+    BoardInfo.Main retrieveBoardInfo(String boardToken);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureServiceImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureServiceImpl.java
@@ -1,0 +1,38 @@
+package com.yapp.ios2.fitfty.domain.picture;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PictureServiceImpl implements PictureService{
+    private final BoardStore pictureStore;
+    private final BoardReader boardReader;
+    private final PictureSeriesFactory pictureSeriesFactory;
+    private final BoardInfoMapper boardInfoMapper;
+
+    @Override
+    @Transactional
+    public Board registerBoard(PictureCommand.RegisterBoardRequest request) {
+        // user 알아내기 임시로 저장
+        Long userToken = 1234L;
+
+        //1. picture 객체 생성 및 저장
+        var picture = pictureSeriesFactory.store(request);
+
+        //2. 보드 저장
+        var initBoard = request.toEntity(userToken, picture);
+        var board = pictureStore.store(initBoard);
+
+        return board;
+    }
+
+    @Override
+    @Transactional
+    public BoardInfo.Main retrieveBoardInfo(String boardToken) {
+        return null;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureServiceImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/picture/PictureServiceImpl.java
@@ -1,5 +1,6 @@
 package com.yapp.ios2.fitfty.domain.picture;
 
+import com.yapp.ios2.fitfty.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,22 +9,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PictureServiceImpl implements PictureService{
+public class PictureServiceImpl implements PictureService {
     private final BoardStore pictureStore;
     private final BoardReader boardReader;
     private final PictureSeriesFactory pictureSeriesFactory;
     private final BoardInfoMapper boardInfoMapper;
+    private final UserService userService;
 
     @Override
     @Transactional
     public Board registerBoard(PictureCommand.RegisterBoardRequest request) {
-        // user 알아내기 임시로 저장
-        Long userToken = 1234L;
-
-        //1. picture 객체 생성 및 저장
-        var picture = pictureSeriesFactory.store(request);
-
-        //2. 보드 저장
+        String userToken = userService.getCurrentUserToken();
+        var picture = pictureSeriesFactory.store(request, userToken);
         var initBoard = request.toEntity(userToken, picture);
         var board = pictureStore.store(initBoard);
 
@@ -32,7 +29,15 @@ public class PictureServiceImpl implements PictureService{
 
     @Override
     @Transactional
+    public void deleteBoard(String boardToken) {
+        var board = boardReader.getBoard(boardToken);
+        board.deleteBoard();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public BoardInfo.Main retrieveBoardInfo(String boardToken) {
-        return null;
+        var board = boardReader.getBoard(boardToken);
+        return boardInfoMapper.of(board);
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
@@ -1,7 +1,6 @@
-package com.yapp.ios2.fitfty.domain.picture.tag;
+package com.yapp.ios2.fitfty.domain.tag;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
-import com.yapp.ios2.fitfty.domain.picture.taggroup.TagGroup;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
@@ -1,9 +1,12 @@
 package com.yapp.ios2.fitfty.domain.tag;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
+import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -17,7 +20,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "tags")
+@Table(name = "tag")
 public class Tag extends AbstractEntity {
 
     @Id
@@ -27,5 +30,18 @@ public class Tag extends AbstractEntity {
     @ManyToOne
     @JoinColumn(name = "tag_group_id")
     private TagGroup tagGroup;
-    private String tagName;
+    private String tagValue;
+
+    @Builder
+    public Tag(TagGroup tagGroup, String tagValue) {
+        if (tagGroup == null) {
+            throw new InvalidParamException("Tag.tagGroup");
+        }
+        if (StringUtils.isBlank(tagValue)) {
+            throw new InvalidParamException("Tag.tagValue");
+        }
+
+        this.tagGroup = tagGroup;
+        this.tagValue = tagValue;
+    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/Tag.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "tag")
+@Table(name = "`tag`")
 public class Tag extends AbstractEntity {
 
     @Id

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -26,7 +26,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "tag_group")
+@Table(name = "`tag_group`")
 public class TagGroup extends AbstractEntity {
 
     @Id

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -3,9 +3,12 @@ package com.yapp.ios2.fitfty.domain.tag;
 import com.google.common.collect.Lists;
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 import com.yapp.ios2.fitfty.domain.picture.Picture;
+import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -23,7 +26,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name = "tag_groups")
+@Table(name = "tag_group")
 public class TagGroup extends AbstractEntity {
 
     @Id
@@ -36,5 +39,23 @@ public class TagGroup extends AbstractEntity {
     private String tagGroupName;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "tagGroup", cascade = CascadeType.PERSIST)
-    private List<Tag> TagList = Lists.newArrayList();
+    private List<Tag> tagList = Lists.newArrayList();
+
+    @Builder
+    public TagGroup(Picture picture, String tagGroupName) {
+        if (picture == null) {
+            throw new InvalidParamException("TagGroup.picture");
+        }
+        if (StringUtils.isBlank(tagGroupName)) {
+            throw new InvalidParamException("TagGroup.tagGroupName");
+        }
+
+        this.picture = picture;
+        this.tagGroupName = tagGroupName;
+    }
+
+    public TagGroup addTag(Tag tag) {
+        this.tagList.add(tag);
+        return this;
+    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -1,9 +1,8 @@
-package com.yapp.ios2.fitfty.domain.picture.taggroup;
+package com.yapp.ios2.fitfty.domain.tag;
 
 import com.google.common.collect.Lists;
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 import com.yapp.ios2.fitfty.domain.picture.Picture;
-import com.yapp.ios2.fitfty.domain.picture.tag.Tag;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroupStore.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroupStore.java
@@ -1,0 +1,5 @@
+package com.yapp.ios2.fitfty.domain.tag;
+
+public interface TagGroupStore {
+    TagGroup store(TagGroup tagGroup);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagStore.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagStore.java
@@ -1,0 +1,5 @@
+package com.yapp.ios2.fitfty.domain.tag;
+
+public interface TagStore {
+    Tag store(Tag tag);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/global/config/SecurityConfig.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .antMatchers("/api/v1/auth/**").permitAll()
                 .antMatchers("/api/v1/users/**").permitAll()
+                .antMatchers("/api/v1/boards/**").permitAll()
+                .antMatchers("/swagger-ui/index.html").permitAll()
                 .requestMatchers(PathRequest.toH2Console())
                 .permitAll()
                 .anyRequest()

--- a/src/main/java/com/yapp/ios2/fitfty/global/util/BooleanToYNConverter.java
+++ b/src/main/java/com/yapp/ios2/fitfty/global/util/BooleanToYNConverter.java
@@ -1,0 +1,17 @@
+package com.yapp.ios2.fitfty.global.util;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class BooleanToYNConverter implements AttributeConverter<Boolean, String> {
+    @Override
+    public String convertToDatabaseColumn(Boolean attribute) {
+        return (attribute != null && attribute) ? "Y" : "N";
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(String dbData) {
+        return "Y".equals(dbData);
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardReaderImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardReaderImpl.java
@@ -1,0 +1,21 @@
+package com.yapp.ios2.fitfty.infrastructure.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import com.yapp.ios2.fitfty.domain.picture.BoardReader;
+import com.yapp.ios2.fitfty.global.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BoardReaderImpl implements BoardReader {
+    private final BoardRepository boardRepository;
+
+    @Override
+    public Board getBoard(String boardToken) {
+        return boardRepository.findByBoardToken(boardToken)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardRepository.java
@@ -1,0 +1,10 @@
+package com.yapp.ios2.fitfty.infrastructure.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    Optional<Board> findByBoardToken(String boardToken);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardStoreImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/BoardStoreImpl.java
@@ -1,0 +1,34 @@
+package com.yapp.ios2.fitfty.infrastructure.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import com.yapp.ios2.fitfty.domain.picture.BoardStore;
+import com.yapp.ios2.fitfty.domain.picture.Picture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BoardStoreImpl implements BoardStore {
+    private final BoardRepository boardRepository;
+    private final PictureRepository pictureRepository;
+
+    @Override
+    public Board store(Board board) {
+        return boardRepository.save(board);
+    }
+
+    @Override
+    public Picture pictureStore(Picture picture) {
+        return pictureRepository.save(picture);
+    }
+
+//    private void validCheck(Item item) {
+//        if (StringUtils.isEmpty(item.getItemToken())) throw new InvalidParamException("Item.itemToken");
+//        if (StringUtils.isEmpty(item.getItemName())) throw new InvalidParamException("Item.itemName");
+//        if (item.getPartnerId() == null) throw new InvalidParamException("Item.partnerId");
+//        if (item.getItemPrice() == null) throw new InvalidParamException("Item.itemPrice");
+//        if (item.getStatus() == null) throw new InvalidParamException("Item.status");
+//    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureRepository.java
@@ -1,0 +1,10 @@
+package com.yapp.ios2.fitfty.infrastructure.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Picture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PictureRepository extends JpaRepository<Picture, Long> {
+    Optional<Picture> findByPictureToken(String pictureToken);
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureSeriesFactoryImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureSeriesFactoryImpl.java
@@ -18,9 +18,8 @@ public class PictureSeriesFactoryImpl implements PictureSeriesFactory {
     private final TagStore tagStore;
 
     @Override
-    public Picture store(PictureCommand.RegisterBoardRequest request) {
-        Long userId = 1234L;
-        var picture = boardStore.pictureStore(request.toPictureEntity(userId));
+    public Picture store(PictureCommand.RegisterBoardRequest request, String userToken) {
+        var picture = boardStore.pictureStore(request.toPictureEntity(userToken));
         var registerTagGroupRequestList = request.getRegisterTagGroupRequestList();
         if (CollectionUtils.isEmpty(registerTagGroupRequestList)) {
             return picture;

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureSeriesFactoryImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/picture/PictureSeriesFactoryImpl.java
@@ -1,0 +1,45 @@
+package com.yapp.ios2.fitfty.infrastructure.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Picture;
+import com.yapp.ios2.fitfty.domain.picture.PictureCommand;
+import com.yapp.ios2.fitfty.domain.picture.PictureSeriesFactory;
+import com.yapp.ios2.fitfty.domain.picture.BoardStore;
+import com.yapp.ios2.fitfty.domain.tag.TagGroupStore;
+import com.yapp.ios2.fitfty.domain.tag.TagStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+@Component
+@RequiredArgsConstructor
+public class PictureSeriesFactoryImpl implements PictureSeriesFactory {
+    private final BoardStore boardStore;
+    private final TagGroupStore tagGroupStore;
+    private final TagStore tagStore;
+
+    @Override
+    public Picture store(PictureCommand.RegisterBoardRequest request) {
+        Long userId = 1234L;
+        var picture = boardStore.pictureStore(request.toPictureEntity(userId));
+        var registerTagGroupRequestList = request.getRegisterTagGroupRequestList();
+        if (CollectionUtils.isEmpty(registerTagGroupRequestList)) {
+            return picture;
+        }
+
+        registerTagGroupRequestList.stream()
+                .map(requestTagGroup -> {
+                    // tagGroup store
+                    var initTagGroup = requestTagGroup.toEntity(picture);
+                    var tagGroup = tagGroupStore.store(initTagGroup);
+
+                    // tag store
+                    requestTagGroup.getRegisterTagRequestList()
+                            .forEach(requestTag -> {
+                                var initTag = requestTag.toEntity(tagGroup);
+                                tagStore.store(initTag);
+                            });
+                    return picture;
+                });
+        return picture;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
@@ -1,0 +1,8 @@
+package com.yapp.ios2.fitfty.infrastructure.tag;
+
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagGroupRepository extends JpaRepository<TagGroup, Long> {
+
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupStoreImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupStoreImpl.java
@@ -1,0 +1,19 @@
+package com.yapp.ios2.fitfty.infrastructure.tag;
+
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.tag.TagGroupStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TagGroupStoreImpl implements TagGroupStore {
+    private final TagGroupRepository tagGroupRepository;
+
+    @Override
+    public TagGroup store(TagGroup tagGroup) {
+        return tagGroupRepository.save(tagGroup);
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagRepository.java
@@ -1,0 +1,7 @@
+package com.yapp.ios2.fitfty.infrastructure.tag;
+
+import com.yapp.ios2.fitfty.domain.tag.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagStoreImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagStoreImpl.java
@@ -1,0 +1,19 @@
+package com.yapp.ios2.fitfty.infrastructure.tag;
+
+import com.yapp.ios2.fitfty.domain.tag.Tag;
+import com.yapp.ios2.fitfty.domain.tag.TagStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TagStoreImpl implements TagStore {
+    private final TagRepository tagRepository;
+    
+    @Override
+    public Tag store(Tag tag) {
+        return tagRepository.save(tag);
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardController.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardController.java
@@ -1,0 +1,56 @@
+package com.yapp.ios2.fitfty.interfaces.picture;
+
+import com.yapp.ios2.fitfty.application.picture.PictureFacade;
+import com.yapp.ios2.fitfty.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.yapp.ios2.fitfty.global.util.Constants.API_PREFIX;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(API_PREFIX + "/boards")
+public class BoardController {
+    private final PictureFacade pictureFacade;
+    private final PictureDtoMapper pictureDtoMapper;
+
+    @PostMapping("/new")
+    public CommonResponse registerBoard(@RequestBody @Valid BoardDto.RegisterBoardRequest request) {
+        var pictureCommand = pictureDtoMapper.of(request);
+        var board = pictureFacade.registerBoard(pictureCommand);
+        var response = pictureDtoMapper.of(board);
+        return CommonResponse.success(response);
+    }
+
+//    @PutMapping("/{boardToken}")
+//    public CommonResponse changeBoardInfo(@PathVariable("boardToken") String boardToken, @RequestBody @Valid BoardDto.ChangeBoardInfoRequest request) {
+//        var userToken = request.getUserToken();
+//        pictureFacade.changeBoardInfo(boardToken);
+//        return CommonResponse.success("OK");
+//    }
+//
+//    @DeleteMapping("/{boardToken}")
+//    public CommonResponse deleteBoard(@PathVariable("boardToken") String boardToken) {
+//        var userToken =
+//        pictureFacade.deleteBoard(boardToken);
+//        return CommonResponse.success("OK");
+//    }
+
+//    @GetMapping("/{boardToken}")
+//    public CommonResponse retrieve(@PathVariable("boardToken") String boardToken) {
+//        var boardInfo = pictureFacade.retrieveBoardInfo(boardToken);
+//        var response = pictureDtoMapper.of(boardInfo);
+//        return CommonResponse.success(response);
+//    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardController.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardController.java
@@ -1,6 +1,6 @@
 package com.yapp.ios2.fitfty.interfaces.picture;
 
-import com.yapp.ios2.fitfty.application.picture.PictureFacade;
+import com.yapp.ios2.fitfty.domain.picture.PictureService;
 import com.yapp.ios2.fitfty.global.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,13 +22,13 @@ import static com.yapp.ios2.fitfty.global.util.Constants.API_PREFIX;
 @RequiredArgsConstructor
 @RequestMapping(API_PREFIX + "/boards")
 public class BoardController {
-    private final PictureFacade pictureFacade;
+    private final PictureService pictureService;
     private final PictureDtoMapper pictureDtoMapper;
 
     @PostMapping("/new")
     public CommonResponse registerBoard(@RequestBody @Valid BoardDto.RegisterBoardRequest request) {
         var pictureCommand = pictureDtoMapper.of(request);
-        var board = pictureFacade.registerBoard(pictureCommand);
+        var board = pictureService.registerBoard(pictureCommand);
         var response = pictureDtoMapper.of(board);
         return CommonResponse.success(response);
     }
@@ -40,17 +40,16 @@ public class BoardController {
 //        return CommonResponse.success("OK");
 //    }
 //
-//    @DeleteMapping("/{boardToken}")
-//    public CommonResponse deleteBoard(@PathVariable("boardToken") String boardToken) {
-//        var userToken =
-//        pictureFacade.deleteBoard(boardToken);
-//        return CommonResponse.success("OK");
-//    }
+    @DeleteMapping("/{boardToken}")
+    public CommonResponse deleteBoard(@PathVariable("boardToken") String boardToken) {
+        pictureService.deleteBoard(boardToken);
+        return CommonResponse.success("OK");
+    }
 
-//    @GetMapping("/{boardToken}")
-//    public CommonResponse retrieve(@PathVariable("boardToken") String boardToken) {
-//        var boardInfo = pictureFacade.retrieveBoardInfo(boardToken);
-//        var response = pictureDtoMapper.of(boardInfo);
-//        return CommonResponse.success(response);
-//    }
+    @GetMapping("/{boardToken}")
+    public CommonResponse retrieve(@PathVariable("boardToken") String boardToken) {
+        var boardInfo = pictureService.retrieveBoardInfo(boardToken);
+        var response = pictureDtoMapper.of(boardInfo);
+        return CommonResponse.success(response);
+    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardDto.java
@@ -25,15 +25,6 @@ public class BoardDto {
         private List<RegisterTagGroupRequest> tagGroupList;
     }
 
-//    @Getter
-//    @Setter
-//    @ToString
-//    public static class RegisterPictureRequest {
-//        private String userToken;
-//        private String filePath;
-//        private List<RegisterTagGroupRequest> tagGroupList;
-//    }
-
     @Getter
     @Setter
     @ToString
@@ -61,20 +52,13 @@ public class BoardDto {
         private Picture picture;
     }
 
-//    @Getter
-//    @Setter
-//    @ToString
-//    public static class ChangeStatusPictureRequest {
-//        private String pictureToken;
-//    }
-
     @Getter
     @Builder
     @ToString
     public static class Main {
         private final String boardToken;
-        private final Long userId;
-        private final Picture picture;
+        private final String userToken;
+        private final String filePath;
         private final String content;
         private final String location;
         private final Float temperature;
@@ -87,7 +71,7 @@ public class BoardDto {
     @ToString
     public static class PictureInfo {
         private final String pictureToken;
-        private final Long userId;
+        private final String userToken;
         private final String pictureName;
         private final Long picturePrice;
         private final List<TagGroupInfo> itemOptionGroupList;

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/BoardDto.java
@@ -1,0 +1,111 @@
+package com.yapp.ios2.fitfty.interfaces.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import com.yapp.ios2.fitfty.domain.picture.Picture;
+import com.yapp.ios2.fitfty.domain.picture.Board.WeatherType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class BoardDto {
+    @Getter
+    @Setter
+    @ToString
+    public static class RegisterBoardRequest {
+        private String filePath;
+        private String content;
+        private Float temperature;
+        private String location;
+        private WeatherType weather;
+        private ZonedDateTime photoTakenTime;
+        private List<RegisterTagGroupRequest> tagGroupList;
+    }
+
+//    @Getter
+//    @Setter
+//    @ToString
+//    public static class RegisterPictureRequest {
+//        private String userToken;
+//        private String filePath;
+//        private List<RegisterTagGroupRequest> tagGroupList;
+//    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class RegisterTagGroupRequest {
+        private String tagGroupName;
+        private List<RegisterTagRequest> tagList;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class RegisterTagRequest {
+        private String tagValue;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class RegisterResponse {
+        private String content;
+        private Float temperature;
+        private String location;
+        private WeatherType weather;
+        private ZonedDateTime photoTakenTime;
+        private Picture picture;
+    }
+
+//    @Getter
+//    @Setter
+//    @ToString
+//    public static class ChangeStatusPictureRequest {
+//        private String pictureToken;
+//    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class Main {
+        private final String boardToken;
+        private final Long userId;
+        private final Picture picture;
+        private final String content;
+        private final String location;
+        private final Float temperature;
+        private final Board.WeatherType weather;
+        private final ZonedDateTime photoTakenTime;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class PictureInfo {
+        private final String pictureToken;
+        private final Long userId;
+        private final String pictureName;
+        private final Long picturePrice;
+        private final List<TagGroupInfo> itemOptionGroupList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class TagGroupInfo {
+        private final String tagGroupType;
+        private final List<TagInfo> tagList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class TagInfo {
+        private final String tagValue;
+    }
+
+}

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/PictureDtoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/picture/PictureDtoMapper.java
@@ -1,0 +1,35 @@
+package com.yapp.ios2.fitfty.interfaces.picture;
+
+import com.yapp.ios2.fitfty.domain.picture.Board;
+import com.yapp.ios2.fitfty.domain.picture.BoardInfo;
+import com.yapp.ios2.fitfty.domain.picture.PictureCommand;
+import org.mapstruct.*;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface PictureDtoMapper {
+    // register
+    @Mappings({@Mapping(source = "request.tagGroupList", target = "registerTagGroupRequestList"),
+            @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss")})
+    PictureCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
+
+    @Mappings({@Mapping(source = "tagList", target = "registerTagRequestList")})
+    PictureCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
+
+    PictureCommand.RegisterTagRequest of(BoardDto.RegisterTagRequest request);
+
+    @Mappings({@Mapping(source = "board.picture", target = "picture")})
+    BoardDto.RegisterResponse of(Board board);
+
+    // retrieve
+    BoardDto.Main of(BoardInfo.Main main);
+
+//    BoardDto.PictureInfo of(BoardInfo.PictureInfo pictureInfo);
+//
+//    BoardDto.TagGroupInfo of(BoardInfo.TagGroupInfo tagGroup);
+//
+//    BoardDto.TagInfo of(BoardInfo.TagInfo tagValue);
+}


### PR DESCRIPTION
### 📙 작업 내역

- [x] Board 생성 api 생성
- [x] Board 삭제 api 생성
- [x] Board 조회 api 생성
- [x] SecurityConfig에서 /boards, /swagger 관련 허용


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📝 리뷰 노트

- 보드 관련 내용이 너무 많아서 PR 한번 끊고, 수정 및 북마크 추가 기능은 브랜치 새로 생성해서 작업하겠습니다
- PictureFacade는 굳이 필요하지 않을 것 같아서 추후에 TagFacade랑 같이 삭제 예정입니다.

- 보드 생성/삭제 여부는 status 컬럼추가해서 Y/N 로 구분합니다. 여기서 화면단에는 status=true 인 항목들만 반환해줄거라서 조회시에 status 검증하는 코드는 추가안했습니다
- 비슷한 의미에서 게시글 삭제/수정 시 해당 요청자체가 프론트에서 작성자인지 검증 후 보내준다고 하셔서 따로 유저 검증하는 부분은 추가 안했는데, 혹시 의견 있으시면 말씀해주세요~~
- SecurityConfig는 일단 처키가 말씀해주신대로 허용할 부분만 추가해놨는데 나중에 리팩토링 어떻게할지 같이 이야기해봐요!

네이밍이 Picture와 Board가 섞여서 헷갈릴 수 있는데 더 적절한 네이밍이 있을것같으면 말씀부탁드립니다!