### PR TITLE
[Ios2 138] 메인페이지 추천코디 반환 api

### DIFF
--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/Board.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/Board.java
@@ -50,7 +50,7 @@ public class Board extends AbstractEntity {
     private Float temperature;
 
     @Enumerated(EnumType.STRING)
-    private WeatherType weather;
+    private CloudType cloudType;
     private ZonedDateTime photoTakenTime; //data 형식 변경 여부 확인
     private Integer views;
     private Integer bookmarkCnt;
@@ -60,7 +60,7 @@ public class Board extends AbstractEntity {
 
     @Builder
     public Board(String userToken, Picture picture, String content, String location,
-                 Float temperature, WeatherType weather, ZonedDateTime photoTakenTime) {
+                 Float temperature, CloudType cloudType, ZonedDateTime photoTakenTime) {
         if (StringUtils.isBlank(userToken)) {
             throw new InvalidParamException("Board.userToken");
         }
@@ -74,7 +74,7 @@ public class Board extends AbstractEntity {
         this.content = content;
         this.location = location;
         this.temperature = temperature;
-        this.weather = weather;
+        this.cloudType = cloudType;
         this.photoTakenTime = photoTakenTime;
         this.views = 0;
         this.bookmarkCnt = 0;
@@ -86,7 +86,7 @@ public class Board extends AbstractEntity {
         this.content = request.getContent();
         this.location = request.getLocation();
         this.temperature = request.getTemperature();
-        this.weather = request.getWeather();
+        this.cloudType = request.getCloudType();
         this.photoTakenTime = request.getPhotoTakenTime();
     }
 
@@ -106,7 +106,7 @@ public class Board extends AbstractEntity {
 
     @Getter
     @RequiredArgsConstructor
-    public enum WeatherType {
+    public enum CloudType {
         SUNNY("맑음"), CLOUDY("구름많음"), GRAY("흐림");
         private final String description;
     }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardCommand.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardCommand.java
@@ -1,6 +1,6 @@
 package com.yapp.ios2.fitfty.domain.board;
 
-import com.yapp.ios2.fitfty.domain.board.Board.WeatherType;
+import com.yapp.ios2.fitfty.domain.board.Board.CloudType;
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,9 +19,9 @@ public class BoardCommand {
         private final String content;
         private final Float temperature;
         private final String location;
-        private final WeatherType weather;
+        private final CloudType cloudType;
         private final ZonedDateTime photoTakenTime;
-        private final List<RegisterTagGroupRequest> registerTagGroupRequestList; //ex) 날씨, 스타일
+        private final RegisterTagGroupRequest registerTagGroupRequest; //ex) 날씨, 스타일, 성별
 
         public Board toEntity(String userToken, Picture picture) {
             return Board.builder()
@@ -30,7 +30,7 @@ public class BoardCommand {
                     .content(content)
                     .location(location)
                     .temperature(temperature)
-                    .weather(weather)
+                    .cloudType(cloudType)
                     .photoTakenTime(photoTakenTime)
                     .build();
         }
@@ -47,24 +47,17 @@ public class BoardCommand {
     @Builder
     @ToString
     public static class RegisterTagGroupRequest {
-//        private final String tagGroupName;  // ex) style, weather
-//        private final String tagValue;  //ex) formal, casual
-
-        private final String weather;
+        private final TagGroup.Weather weather;
         private final List<String> style;
+        private final TagGroup.Gender gender;
 
         public TagGroup toEntity(Picture picture) {
             return TagGroup.builder()
                     .picture(picture)
                     .weather(weather)
                     .style(style)
+                    .gender(gender)
                     .build();
-
-//            return TagGroup.builder()
-//                    .picture(picture)
-//                    .tagGroupName(tagGroupName)
-//                    .tagValue(tagValue)
-//                    .build();
         }
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardCommand.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardCommand.java
@@ -47,15 +47,24 @@ public class BoardCommand {
     @Builder
     @ToString
     public static class RegisterTagGroupRequest {
-        private final String tagGroupName;  // ex) style, weather
-        private final String tagValue;  //ex) formal, casual
+//        private final String tagGroupName;  // ex) style, weather
+//        private final String tagValue;  //ex) formal, casual
+
+        private final String weather;
+        private final List<String> style;
 
         public TagGroup toEntity(Picture picture) {
             return TagGroup.builder()
                     .picture(picture)
-                    .tagGroupName(tagGroupName)
-                    .tagValue(tagValue)
+                    .weather(weather)
+                    .style(style)
                     .build();
+
+//            return TagGroup.builder()
+//                    .picture(picture)
+//                    .tagGroupName(tagGroupName)
+//                    .tagValue(tagValue)
+//                    .build();
         }
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
@@ -30,8 +30,10 @@ public class BoardInfo {
     @Builder
     @ToString
     public static class TagGroupInfo {
-        private final String tagGroupName;
-        private final String tagValue;
+        // private final String tagGroupName;
+        // private final String tagValue;
+        private final String weather;
+        private final List<String> style;
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
@@ -1,5 +1,6 @@
 package com.yapp.ios2.fitfty.domain.board;
 
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -15,12 +16,12 @@ public class BoardInfo {
     public static class Main {
         private final Long boardId;
         private final String boardToken;
-        private final String userToken;
+        private final String nickname;
         private final String filePath;
         private final String content;
         private final String location;
         private final Float temperature;
-        private final Board.WeatherType weather;
+        private final Board.CloudType cloudType;
         private final ZonedDateTime photoTakenTime;
         private final Integer views;
         private final Integer bookmarkCnt;
@@ -30,10 +31,9 @@ public class BoardInfo {
     @Builder
     @ToString
     public static class TagGroupInfo {
-        // private final String tagGroupName;
-        // private final String tagValue;
-        private final String weather;
+        private final TagGroup.Weather weather;
         private final List<String> style;
+        private final TagGroup.Gender gender;
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
@@ -29,16 +29,6 @@ public class BoardInfo {
     @Getter
     @Builder
     @ToString
-    public static class PictureInfo {
-        private final String pictureToken;
-        private final String userToken;
-        private final String filePath;
-        private final List<TagGroupInfo> tagGroupList;
-    }
-
-    @Getter
-    @Builder
-    @ToString
     public static class TagGroupInfo {
         private final String tagGroupName;
         private final String tagValue;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
@@ -9,25 +9,30 @@ import org.mapstruct.ReportingPolicy;
 
 import java.util.List;
 
-@Mapper(
-        componentModel = "spring",
-        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-        unmappedTargetPolicy = ReportingPolicy.ERROR
-)
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface BoardInfoMapper {
-    @Mappings({
-            @Mapping(source = "board.id", target = "boardId"),
-            @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath")
-    })
-    BoardInfo.Main of(Board board);
+        @Mappings({
+                        @Mapping(source = "board.id", target = "boardId"),
+                        @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath")
+        })
+        BoardInfo.Main of(Board board);
 
-    BoardInfo.TagGroupInfo of(TagGroup tagGroup);
+        BoardInfo.TagGroupInfo of(TagGroup tagGroup);
 
-    BoardInfo.PicturePathInfo toPicturePathInfo(Picture picture);
+        BoardInfo.PicturePathInfo toPicturePathInfo(Picture picture);
 
-//    PictureInfo.Main toPictureInfo(List<PictureInfo.StyleInfo> styleInfoList);
-//
-//    PictureInfo.StyleInfo of(String style, List<PictureInfo.PictureDetailInfo> pictureInfoList);
-//
-//    PictureInfo.PictureDetailInfo of(String filePath)
+        // PictureInfo.Main toPictureInfo(List<PictureInfo.StyleInfo> styleInfoList);
+        //
+        // PictureInfo.StyleInfo of(String style, List<PictureInfo.PictureDetailInfo>
+        // pictureInfoList);
+        //
+        // @Mappings({
+        // @Mapping(source = "board.views", target = "views"),
+        // @Mapping(expression = "java(board.getPicture().getFilePath())", target =
+        // "filePath"),
+        // @Mapping(source = "nickname", target = "nickname"),
+        // @Mapping(source = "bookmarked", target = "bookmarked"),
+        // })
+        // PictureInfo.PictureDetailInfo of(Board board, String nickname, Boolean
+        // bookmarked);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
@@ -7,6 +7,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
+
 @Mapper(
         componentModel = "spring",
         injectionStrategy = InjectionStrategy.CONSTRUCTOR,
@@ -19,9 +21,13 @@ public interface BoardInfoMapper {
     })
     BoardInfo.Main of(Board board);
 
-    BoardInfo.PictureInfo of(Picture picture);
-
     BoardInfo.TagGroupInfo of(TagGroup tagGroup);
 
     BoardInfo.PicturePathInfo toPicturePathInfo(Picture picture);
+
+//    PictureInfo.Main toPictureInfo(List<PictureInfo.StyleInfo> styleInfoList);
+//
+//    PictureInfo.StyleInfo of(String style, List<PictureInfo.PictureDetailInfo> pictureInfoList);
+//
+//    PictureInfo.PictureDetailInfo of(String filePath)
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
@@ -1,38 +1,23 @@
 package com.yapp.ios2.fitfty.domain.board;
 
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.user.User;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 
-import java.util.List;
-
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface BoardInfoMapper {
-        @Mappings({
-                        @Mapping(source = "board.id", target = "boardId"),
-                        @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath")
-        })
-        BoardInfo.Main of(Board board);
+    @Mappings({
+            @Mapping(source = "board.id", target = "boardId"),
+            @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath"),
+            @Mapping(expression = "java(user.getNickname())", target = "nickname")
+    })
+    BoardInfo.Main of(Board board, User user);
 
-        BoardInfo.TagGroupInfo of(TagGroup tagGroup);
+    BoardInfo.TagGroupInfo of(TagGroup tagGroup);
 
-        BoardInfo.PicturePathInfo toPicturePathInfo(Picture picture);
-
-        // PictureInfo.Main toPictureInfo(List<PictureInfo.StyleInfo> styleInfoList);
-        //
-        // PictureInfo.StyleInfo of(String style, List<PictureInfo.PictureDetailInfo>
-        // pictureInfoList);
-        //
-        // @Mappings({
-        // @Mapping(source = "board.views", target = "views"),
-        // @Mapping(expression = "java(board.getPicture().getFilePath())", target =
-        // "filePath"),
-        // @Mapping(source = "nickname", target = "nickname"),
-        // @Mapping(source = "bookmarked", target = "bookmarked"),
-        // })
-        // PictureInfo.PictureDetailInfo of(Board board, String nickname, Boolean
-        // bookmarked);
+    BoardInfo.PicturePathInfo toPicturePathInfo(Picture picture);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
@@ -1,6 +1,7 @@
 package com.yapp.ios2.fitfty.domain.board;
 
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.user.User;
 import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
 
 import java.util.List;
@@ -8,5 +9,5 @@ import java.util.List;
 public interface BoardReader {
     Board getBoard(String boardToken);
     List<PictureInfo.StyleInfo> getPictureSeries(String userToken, String weather);
-    List<TagGroup> getRandomPicture(String style, String weather);
+    List<TagGroup> getRandomPicture(String style, String weather, User.Gender gender);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
@@ -1,5 +1,6 @@
 package com.yapp.ios2.fitfty.domain.board;
 
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
 
 import java.util.List;
@@ -7,5 +8,5 @@ import java.util.List;
 public interface BoardReader {
     Board getBoard(String boardToken);
     List<PictureInfo.StyleInfo> getPictureSeries(String userToken, String weather);
-    List<PictureInfo.PictureDetailInfo> getRandomPicture(String tagValue);
+    List<TagGroup> getRandomPicture(String style, String weather);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardReader.java
@@ -1,5 +1,11 @@
 package com.yapp.ios2.fitfty.domain.board;
 
+import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
+
+import java.util.List;
+
 public interface BoardReader {
     Board getBoard(String boardToken);
+    List<PictureInfo.StyleInfo> getPictureSeries(String userToken, String weather);
+    List<PictureInfo.PictureDetailInfo> getRandomPicture(String tagValue);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardService.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardService.java
@@ -5,8 +5,8 @@ import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
 public interface BoardService {
     Board registerBoard(BoardCommand.RegisterBoardRequest request);
     BoardInfo.Main retrieveBoardInfo(String boardToken);
-    BoardInfo.Main changeBoardInfo(BoardCommand.RegisterBoardRequest request, String boardToken);
     PictureInfo.Main getPictureList(BoardDto.GetPictureRequest request);
+    void changeBoardInfo(BoardCommand.RegisterBoardRequest request, String boardToken);
     void deleteBoard(String boardToken);
     void addBookmark(String boardToken);
     void deleteBookmark(String boardToken);

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardService.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardService.java
@@ -1,9 +1,12 @@
 package com.yapp.ios2.fitfty.domain.board;
 
+import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
+
 public interface BoardService {
     Board registerBoard(BoardCommand.RegisterBoardRequest request);
     BoardInfo.Main retrieveBoardInfo(String boardToken);
     BoardInfo.Main changeBoardInfo(BoardCommand.RegisterBoardRequest request, String boardToken);
+    PictureInfo.Main getPictureList(BoardDto.GetPictureRequest request);
     void deleteBoard(String boardToken);
     void addBookmark(String boardToken);
     void deleteBookmark(String boardToken);

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
@@ -34,7 +34,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public BoardInfo.Main changeBoardInfo(BoardCommand.RegisterBoardRequest request,
-                                          String boardToken) {
+            String boardToken) {
         var board = boardReader.getBoard(boardToken);
         var picture = board.getPicture();
         picture.update(request);
@@ -83,19 +83,13 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public PictureInfo.Main getPictureList(BoardDto.GetPictureRequest request) {
-        //        1. 유저찾기 by userToken
-//        2. get user preference, bookmark list from userService
-//        3. style, weather tag로 s3 link 5개씩 찾아오기 (repository)
-//                4. picture dto로부터 board info 찾기
-//        1. user code, view, bookmark 여부 return
-//                2. bookmark list에 있는지 contains() 메서드로 확인하기
-//        3. 조회수 + 1
-//        5. return response
-
-//        var picture = pictureSeriesFactory.store(request, userToken);
-//        var initBoard = request.toEntity(userToken, picture);
-//        var board = pictureStore.store(initBoard);
-//        userService.addUserFeed(userMapper.toUserFeedCommand(userToken, board.getBoardToken()));
+        // 1. 유저찾기 by userToken
+        // 2. get user preference, bookmark list from userService
+        // 3. style, weather tag로 s3 link 5개씩 찾아오기 (repository)
+        // 4. picture dto로부터 board info 찾기
+        // 1. user code, view, bookmark 여부 return
+        // 3. 조회수 + 1
+        // 5. return response
 
         String userToken = userService.getCurrentUserToken();
         var styleInfoList = boardReader.getPictureSeries(userToken, request.getWeather());

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
@@ -2,6 +2,7 @@ package com.yapp.ios2.fitfty.domain.board;
 
 import com.yapp.ios2.fitfty.domain.user.UserMapper;
 import com.yapp.ios2.fitfty.domain.user.UserService;
+import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -77,5 +78,27 @@ public class BoardServiceImpl implements BoardService {
         board.decreaseBookmarkCnt();
 
         userService.deleteBookmark(userMapper.toBookmarkCommand(userToken, boardToken));
+    }
+
+    @Override
+    @Transactional
+    public PictureInfo.Main getPictureList(BoardDto.GetPictureRequest request) {
+        //        1. 유저찾기 by userToken
+//        2. get user preference, bookmark list from userService
+//        3. style, weather tag로 s3 link 5개씩 찾아오기 (repository)
+//                4. picture dto로부터 board info 찾기
+//        1. user code, view, bookmark 여부 return
+//                2. bookmark list에 있는지 contains() 메서드로 확인하기
+//        3. 조회수 + 1
+//        5. return response
+
+//        var picture = pictureSeriesFactory.store(request, userToken);
+//        var initBoard = request.toEntity(userToken, picture);
+//        var board = pictureStore.store(initBoard);
+//        userService.addUserFeed(userMapper.toUserFeedCommand(userToken, board.getBoardToken()));
+
+        String userToken = userService.getCurrentUserToken();
+        var styleInfoList = boardReader.getPictureSeries(userToken, request.getWeather());
+        return new PictureInfo.Main(styleInfoList);
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/Picture.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/Picture.java
@@ -17,7 +17,9 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,8 +39,8 @@ public class Picture extends AbstractEntity {
     private String userToken;
     private String filePath;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "picture", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TagGroup> tagGroupList = Lists.newArrayList();
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "picture", cascade = CascadeType.ALL)
+    private TagGroup tagGroup;
 
     @Builder
     public Picture(String userToken, String filePath) {
@@ -54,14 +56,8 @@ public class Picture extends AbstractEntity {
         this.filePath = filePath;
     }
 
-    public void update(BoardCommand.RegisterBoardRequest request) {
+    public void update(BoardCommand.RegisterBoardRequest request, TagGroup tagGroup) {
         this.filePath = request.getFilePath();
-        var registerTagGroupRequestList = request.getRegisterTagGroupRequestList();
-
-        tagGroupList.clear();
-        tagGroupList.addAll(registerTagGroupRequestList.stream()
-                                    .map(requestTagGroup -> requestTagGroup.toEntity(this))
-                                    .collect(Collectors.toList()));
-
+        this.tagGroup = tagGroup;
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
@@ -2,6 +2,7 @@ package com.yapp.ios2.fitfty.domain.board;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 import java.lang.annotation.Repeatable;
@@ -26,7 +27,6 @@ public class PictureInfo {
     }
 
     @Getter
-    @Builder
     @ToString
     public static class PictureDetailInfo {
         private final String filePath;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.lang.annotation.Repeatable;
 import java.util.List;
 
 public class PictureInfo {
@@ -16,8 +17,9 @@ public class PictureInfo {
     }
 
     @Getter
-    @Builder
+    // @Builder
     @ToString
+    @RequiredArgsConstructor
     public static class StyleInfo {
         private final String style;
         private final List<PictureDetailInfo> pictureInfoList;
@@ -31,5 +33,12 @@ public class PictureInfo {
         private final String nickname;
         private final Integer views;
         private final Boolean bookmarked;
+
+        public PictureDetailInfo(Board board, String nickname, Boolean bookmarked) {
+            this.filePath = board.getPicture().getFilePath();
+            this.nickname = nickname;
+            this.views = board.getViews();
+            this.bookmarked = bookmarked;
+        }
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
@@ -1,0 +1,35 @@
+package com.yapp.ios2.fitfty.domain.board;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+public class PictureInfo {
+
+    @Getter
+    @Builder
+    @ToString
+    public static class Main {
+        private final List<StyleInfo> styleInfoList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class StyleInfo {
+        private final String style;
+        private final List<PictureDetailInfo> pictureInfoList;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class PictureDetailInfo {
+        private final String filePath;
+        private final String nickname;
+        private final Integer views;
+        private final Boolean bookmarked;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-import java.lang.annotation.Repeatable;
 import java.util.List;
 
 public class PictureInfo {
@@ -18,7 +17,6 @@ public class PictureInfo {
     }
 
     @Getter
-    // @Builder
     @ToString
     @RequiredArgsConstructor
     public static class StyleInfo {
@@ -35,7 +33,8 @@ public class PictureInfo {
         private final Boolean bookmarked;
 
         public PictureDetailInfo(Board board, String nickname, Boolean bookmarked) {
-            this.filePath = board.getPicture().getFilePath();
+            this.filePath = board.getPicture()
+                    .getFilePath();
             this.nickname = nickname;
             this.views = board.getViews();
             this.bookmarked = bookmarked;

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureSeriesFactory.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureSeriesFactory.java
@@ -2,6 +2,4 @@ package com.yapp.ios2.fitfty.domain.board;
 
 public interface PictureSeriesFactory {
     Picture store(BoardCommand.RegisterBoardRequest request, String userToken);
-
-    Picture storeTagSeries(BoardCommand.RegisterBoardRequest request, Picture picture);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -84,18 +84,4 @@ public class TagGroup extends AbstractEntity {
 
         private final String description;
     }
-
-    @Getter
-    @RequiredArgsConstructor
-    public enum Style {
-        MINIMAL("미니멀"),
-        MODERN("모던"),
-        CASUAL("캐주얼"),
-        STREET("스트릿"),
-        LOVELY("러블리"),
-        HIP("힙"),
-        LUXURY("럭셔리");
-
-        private final String description;
-    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -2,6 +2,7 @@ package com.yapp.ios2.fitfty.domain.tag;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
 import com.yapp.ios2.fitfty.domain.board.Picture;
+import com.yapp.ios2.fitfty.domain.user.Utils.StringListConverter;
 import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,13 +11,8 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
+import java.util.List;
 
 @Slf4j
 @Getter
@@ -61,5 +57,9 @@ public class TagGroup extends AbstractEntity {
         this.picture = picture;
         this.weather = weather;
         this.style = style;
+    }
+
+    public Long getPictureId() {
+        return picture.getId();
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -1,15 +1,16 @@
 package com.yapp.ios2.fitfty.domain.tag;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
+import com.yapp.ios2.fitfty.domain.board.BoardCommand;
 import com.yapp.ios2.fitfty.domain.board.Picture;
 import com.yapp.ios2.fitfty.domain.user.Utils.StringListConverter;
 import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.*;
 import java.util.List;
@@ -25,41 +26,76 @@ public class TagGroup extends AbstractEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @Setter
     @JoinColumn(name = "picture_id")
     private Picture picture;
-    // private String tagGroupName;
-    private String weather;
+
+    @Enumerated(EnumType.STRING)
+    private Weather weather;
 
     @Convert(converter = StringListConverter.class)
     private List<String> style;
 
-    // @Builder
-    // public TagGroup(Picture picture, String tagGroupName, String tagValue) {
-    // if (picture == null) {
-    // throw new InvalidParamException("TagGroup.picture");
-    // }
-    // if (StringUtils.isBlank(tagGroupName)) {
-    // throw new InvalidParamException("TagGroup.tagGroupName");
-    // }
-
-    // this.picture = picture;
-    // this.tagGroupName = tagGroupName;
-    // this.tagValue = tagValue;
-    // }
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     @Builder
-    public TagGroup(Picture picture, String weather, List<String> style) {
+    public TagGroup(Picture picture, Weather weather, List<String> style, Gender gender) {
         if (picture == null) {
             throw new InvalidParamException("TagGroup.picture");
         }
         this.picture = picture;
         this.weather = weather;
         this.style = style;
+        this.gender = gender;
     }
 
     public Long getPictureId() {
         return picture.getId();
+    }
+
+    public void update(BoardCommand.RegisterBoardRequest request) {
+        this.weather = request.getRegisterTagGroupRequest()
+                .getWeather();
+        this.style = request.getRegisterTagGroupRequest()
+                .getStyle();
+        this.gender = request.getRegisterTagGroupRequest()
+                .getGender();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Gender {
+        FEMALE("여성"),
+        MALE("남성");
+
+        private final String description;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Weather {
+        FREEZING("한파"),
+        COLD("추운 날"),
+        CHILLY("쌀쌀한 날"),
+        WARM("따뜻한 날"),
+        HOT("더운 날");
+
+        private final String description;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Style {
+        MINIMAL("미니멀"),
+        MODERN("모던"),
+        CASUAL("캐주얼"),
+        STREET("스트릿"),
+        LOVELY("러블리"),
+        HIP("힙"),
+        LUXURY("럭셔리");
+
+        private final String description;
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/tag/TagGroup.java
@@ -33,20 +33,33 @@ public class TagGroup extends AbstractEntity {
     @Setter
     @JoinColumn(name = "picture_id")
     private Picture picture;
-    private String tagGroupName;
-    private String tagValue;
+    // private String tagGroupName;
+    private String weather;
+
+    @Convert(converter = StringListConverter.class)
+    private List<String> style;
+
+    // @Builder
+    // public TagGroup(Picture picture, String tagGroupName, String tagValue) {
+    // if (picture == null) {
+    // throw new InvalidParamException("TagGroup.picture");
+    // }
+    // if (StringUtils.isBlank(tagGroupName)) {
+    // throw new InvalidParamException("TagGroup.tagGroupName");
+    // }
+
+    // this.picture = picture;
+    // this.tagGroupName = tagGroupName;
+    // this.tagValue = tagValue;
+    // }
 
     @Builder
-    public TagGroup(Picture picture, String tagGroupName, String tagValue) {
+    public TagGroup(Picture picture, String weather, List<String> style) {
         if (picture == null) {
             throw new InvalidParamException("TagGroup.picture");
         }
-        if (StringUtils.isBlank(tagGroupName)) {
-            throw new InvalidParamException("TagGroup.tagGroupName");
-        }
-
         this.picture = picture;
-        this.tagGroupName = tagGroupName;
-        this.tagValue = tagValue;
+        this.weather = weather;
+        this.style = style;
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardReaderImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardReaderImpl.java
@@ -2,20 +2,107 @@ package com.yapp.ios2.fitfty.infrastructure.board;
 
 import com.yapp.ios2.fitfty.domain.board.Board;
 import com.yapp.ios2.fitfty.domain.board.BoardReader;
+import com.yapp.ios2.fitfty.domain.board.PictureInfo;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.user.UserReader;
 import com.yapp.ios2.fitfty.global.exception.EntityNotFoundException;
+import com.yapp.ios2.fitfty.infrastructure.tag.TagGroupRepository;
+import com.yapp.ios2.fitfty.infrastructure.user.UserRepository;
+import com.yapp.ios2.fitfty.interfaces.board.BoardDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class BoardReaderImpl implements BoardReader {
     private final BoardRepository boardRepository;
+    private final TagGroupRepository tagGroupRepository;
+    private final UserReader userReader;
 
     @Override
     public Board getBoard(String boardToken) {
         return boardRepository.findByBoardToken(boardToken)
                 .orElseThrow(EntityNotFoundException::new);
+    }
+
+    @Override
+    public List<PictureInfo.StyleInfo> getPictureSeries(String userToken, String weather) {
+//        style, weather tag로 s3 link 5개씩 찾아오기 (repository)
+//                4. picture dto로부터 board info 찾기
+//        1. user code, view, bookmark 여부 return
+//                2. bookmark list에 있는지 contains() 메서드로 확인하기
+//        3. 조회수 + 1
+
+//        userReader.findOneByNickname(nickname)
+//                .isPresent();
+
+        var bookmarkList = userReader.findBookmarkByUserToken(userToken);
+        var user = userReader.findOneByUserToken(userToken);
+//        var pictureList = user.getStyle().stream()
+//                .map(style -> {
+//                    var picutreDetailList = getRandomPicture(style);
+//
+//                     PictureInfo.PictureDetailInfo.builder()
+//                            .filePath()
+//                            .nickname(user.getNickname())
+//                            .views()
+//                            .bookmarked()
+//                            .build();
+//
+//                    return PictureInfo.StyleInfo.builder()
+//                            .style(style)
+//                            .pictureInfoList()
+//                            .build();
+//                }).collect(Collectors.toList());
+//
+//        var itemOptionGroupList = item.getItemOptionGroupList();
+//        return itemOptionGroupList.stream()
+//                .map(itemOptionGroup -> {
+//                    var itemOptionList = itemOptionGroup.getItemOptionList();
+//                    var itemOptionInfoList = itemOptionList.stream()
+//                            .map(ItemInfo.ItemOptionInfo::new)
+//                            .collect(Collectors.toList());
+//
+//                    return new ItemInfo.ItemOptionGroupInfo(itemOptionGroup, itemOptionInfoList);
+//                }).collect(Collectors.toList());
+
+
+        return null;
+
+    }
+
+    @Override
+    public List<PictureInfo.PictureDetailInfo> getRandomPicture(String tagValue) {
+//        var tagGroup = tagGroupRepository.findByTagValue(tagValue);
+
+//        var size = tagGroupRepository.getNumberOfTagGroup();
+//        var randomList = generateNumbers(System.currentTimeMillis(), size); // 날짜 기준으로 변경
+//
+//        int[] index = new Random().ints(0, size, 10).toArray();
+
+        // 날짜 기준으로 변경
+        List<TagGroup> tagGroupList = tagGroupRepository.findRandomPicture();
+
+//        Query query = em.createQuery("SELECT u FROM UserTable u WHERE INDEX(u) IN :indexs");
+//        query.setParameter("indexs", index);
+//        List<UserTable> listUsersRandom = query.getResultList();
+        return null;
+    }
+
+    public double[] generateNumbers(long seed, int amount) {
+        double[] randomList = new double[amount];
+        for (int i=0;i<amount;i++) {
+            Random generator = new Random(seed);
+            randomList[i] = Math.abs((double) (generator.nextLong() % 0.001) * 10000);
+            seed--;
+        }
+        return randomList;
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByBoardToken(String boardToken);
+
+    Optional<Board> findByPictureId(Long pictureId);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PictureRepository extends JpaRepository<Picture, Long> {
+    Optional<Picture> findById(String pictureId);
+
     Optional<Picture> findByPictureToken(String pictureToken);
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 public class PictureSeriesFactoryImpl implements PictureSeriesFactory {
     private final BoardStore boardStore;
     private final TagGroupStore tagGroupStore;
-    private final TagStore tagStore;
 
     @Override
     public Picture store(BoardCommand.RegisterBoardRequest request, String userToken) {

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
@@ -23,26 +23,32 @@ public class PictureSeriesFactoryImpl implements PictureSeriesFactory {
     @Override
     public Picture store(BoardCommand.RegisterBoardRequest request, String userToken) {
         var picture = boardStore.pictureStore(request.toPictureEntity(userToken));
-        storeTagSeries(request, picture);
+        var registerTagGroupRequest = request.getRegisterTagGroupRequest();
+        System.out.println(picture);
+
+        var initTagGroup = registerTagGroupRequest.toEntity(picture);
+        var tagGroup = tagGroupStore.store(initTagGroup);
+//        storeTagSeries(request, picture);
         return picture;
     }
 
     @Override
     public Picture storeTagSeries(BoardCommand.RegisterBoardRequest request, Picture picture) {
-        var registerTagGroupRequestList = request.getRegisterTagGroupRequestList();
-        if (CollectionUtils.isEmpty(registerTagGroupRequestList)) {
-            return picture;
-        }
+        var registerTagGroupRequest = request.getRegisterTagGroupRequest();
 
-        registerTagGroupRequestList.stream()
-                .map(requestTagGroup -> {
-                    // tagGroup store
-                    var initTagGroup = requestTagGroup.toEntity(picture);
-                    var tagGroup = tagGroupStore.store(initTagGroup);
+        var initTagGroup = registerTagGroupRequest.toEntity(picture);
+        var tagGroup = tagGroupStore.store(initTagGroup);
 
-                    return initTagGroup;
-                })
-                .collect(Collectors.toList());
         return picture;
+
+//        registerTagGroupRequest.stream()
+//                .map(requestTagGroup -> {
+//                    // tagGroup store
+//                    var initTagGroup = requestTagGroup.toEntity(picture);
+//                    var tagGroup = tagGroupStore.store(initTagGroup);
+//
+//                    return initTagGroup;
+//                })
+//                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/PictureSeriesFactoryImpl.java
@@ -5,13 +5,9 @@ import com.yapp.ios2.fitfty.domain.board.BoardStore;
 import com.yapp.ios2.fitfty.domain.board.Picture;
 import com.yapp.ios2.fitfty.domain.board.PictureSeriesFactory;
 import com.yapp.ios2.fitfty.domain.tag.TagGroupStore;
-import com.yapp.ios2.fitfty.domain.tag.TagStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
-
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -24,31 +20,9 @@ public class PictureSeriesFactoryImpl implements PictureSeriesFactory {
     public Picture store(BoardCommand.RegisterBoardRequest request, String userToken) {
         var picture = boardStore.pictureStore(request.toPictureEntity(userToken));
         var registerTagGroupRequest = request.getRegisterTagGroupRequest();
-        System.out.println(picture);
-
         var initTagGroup = registerTagGroupRequest.toEntity(picture);
-        var tagGroup = tagGroupStore.store(initTagGroup);
-//        storeTagSeries(request, picture);
+        tagGroupStore.store(initTagGroup);
         return picture;
     }
 
-    @Override
-    public Picture storeTagSeries(BoardCommand.RegisterBoardRequest request, Picture picture) {
-        var registerTagGroupRequest = request.getRegisterTagGroupRequest();
-
-        var initTagGroup = registerTagGroupRequest.toEntity(picture);
-        var tagGroup = tagGroupStore.store(initTagGroup);
-
-        return picture;
-
-//        registerTagGroupRequest.stream()
-//                .map(requestTagGroup -> {
-//                    // tagGroup store
-//                    var initTagGroup = requestTagGroup.toEntity(picture);
-//                    var tagGroup = tagGroupStore.store(initTagGroup);
-//
-//                    return initTagGroup;
-//                })
-//                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
@@ -1,6 +1,7 @@
 package com.yapp.ios2.fitfty.infrastructure.tag;
 
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
+import com.yapp.ios2.fitfty.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,16 +10,15 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TagGroupRepository extends JpaRepository<TagGroup, Long> {
-//    Optional<TagGroup> findByTagValue(String tagValue);
-
-    @Query(nativeQuery = true, value = "SELECT *" +
-            "FROM tag_group" +
-            "WHERE style = :style AND weather = :weather" +
+    @Query(nativeQuery = true, value = "SELECT * " +
+            "FROM tag_group " +
+            "WHERE style LIKE :style AND weather = :weather AND gender = :gender " +
             "ORDER BY RAND(:seed) LIMIT 5 OFFSET :offset")
     List<TagGroup> findRandomPicture(@Param("style") String style, @Param("weather") String weather,
+                                     @Param("gender") String gender,
                                      @Param("seed") long seed, @Param("offset") int offset);
 
-    @Query(nativeQuery = true, value = "SELECT COUNT(t) FROM tag_group t")
+    @Query(nativeQuery = true, value = "SELECT COUNT(*) FROM tag_group")
     int getNumberOfTagGroup();
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
@@ -10,14 +10,14 @@ import java.util.Optional;
 public interface TagGroupRepository extends JpaRepository<TagGroup, Long> {
     Optional<TagGroup> findByTagValue(String tagValue);
 
-//    @Query(nativeQuery=true, value="SELECT *  FROM question ORDER BY random() LIMIT 10")
-    @Query(nativeQuery = true, value="SELECT * FROM yourTableName ORDER BY RAND() LIMIT 10 OFFSET floor(rand()(SELECT COUNT() FROM yourTableName))")
-    List<TagGroup> findRandomPicture();
+    @Query(nativeQuery = true, value = "SELECT *" +
+            "FROM tag_group" +
+            "WHERE style = :style AND weather = :weather" +
+            "ORDER BY RAND(:seed) LIMIT 5 OFFSET :offset")
+    List<TagGroup> findRandomPicture(@Param("style") String style, @Param("weather") String weather,
+            @Param("seed") long seed, @Param("offset") int offset);
 
-//    @Query("SELECT COUNT(t) FROM tag_group t")
-//    int getNumberOfTagGroup();
-
-//    @Query("SELECT u FROM tag_group u WHERE INDEX(u) IN :indexs")
-//    List<TagGroup> getResultList(int[] indexes);
+    @Query("SELECT COUNT(t) FROM tag_group t")
+    int getNumberOfTagGroup();
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
@@ -3,21 +3,22 @@ package com.yapp.ios2.fitfty.infrastructure.tag;
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface TagGroupRepository extends JpaRepository<TagGroup, Long> {
-    Optional<TagGroup> findByTagValue(String tagValue);
+//    Optional<TagGroup> findByTagValue(String tagValue);
 
     @Query(nativeQuery = true, value = "SELECT *" +
             "FROM tag_group" +
             "WHERE style = :style AND weather = :weather" +
             "ORDER BY RAND(:seed) LIMIT 5 OFFSET :offset")
     List<TagGroup> findRandomPicture(@Param("style") String style, @Param("weather") String weather,
-            @Param("seed") long seed, @Param("offset") int offset);
+                                     @Param("seed") long seed, @Param("offset") int offset);
 
-    @Query("SELECT COUNT(t) FROM tag_group t")
+    @Query(nativeQuery = true, value = "SELECT COUNT(t) FROM tag_group t")
     int getNumberOfTagGroup();
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/tag/TagGroupRepository.java
@@ -2,7 +2,22 @@ package com.yapp.ios2.fitfty.infrastructure.tag;
 
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface TagGroupRepository extends JpaRepository<TagGroup, Long> {
+    Optional<TagGroup> findByTagValue(String tagValue);
+
+//    @Query(nativeQuery=true, value="SELECT *  FROM question ORDER BY random() LIMIT 10")
+    @Query(nativeQuery = true, value="SELECT * FROM yourTableName ORDER BY RAND() LIMIT 10 OFFSET floor(rand()(SELECT COUNT() FROM yourTableName))")
+    List<TagGroup> findRandomPicture();
+
+//    @Query("SELECT COUNT(t) FROM tag_group t")
+//    int getNumberOfTagGroup();
+
+//    @Query("SELECT u FROM tag_group u WHERE INDEX(u) IN :indexs")
+//    List<TagGroup> getResultList(int[] indexes);
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardController.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardController.java
@@ -41,9 +41,8 @@ public class BoardController {
     public CommonResponse changeBoardInfo(@PathVariable("boardToken") String boardToken,
                                           @RequestBody @Valid BoardDto.RegisterBoardRequest request) {
         var boardCommand = boardDtoMapper.of(request);
-        var boardInfo = boardService.changeBoardInfo(boardCommand, boardToken);
-        var response = boardDtoMapper.of(boardInfo);
-        return CommonResponse.success(response);
+        boardService.changeBoardInfo(boardCommand, boardToken);
+        return CommonResponse.success("OK");
     }
 
     @GetMapping("/{boardToken}")

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardController.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardController.java
@@ -30,8 +30,8 @@ public class BoardController {
     @PostMapping("/new")
     @PreAuthorize("hasAnyRole('ROLE_USER','ROLE_ADMIN')")
     public CommonResponse registerBoard(@RequestBody @Valid BoardDto.RegisterBoardRequest request) {
-        var pictureCommand = boardDtoMapper.of(request);
-        var board = boardService.registerBoard(pictureCommand);
+        var boardCommand = boardDtoMapper.of(request);
+        var board = boardService.registerBoard(boardCommand);
         var response = boardDtoMapper.of(board);
         return CommonResponse.success(response);
     }
@@ -40,8 +40,8 @@ public class BoardController {
     @PreAuthorize("hasAnyRole('ROLE_USER','ROLE_ADMIN')")
     public CommonResponse changeBoardInfo(@PathVariable("boardToken") String boardToken,
                                           @RequestBody @Valid BoardDto.RegisterBoardRequest request) {
-        var pictureCommand = boardDtoMapper.of(request);
-        var boardInfo = boardService.changeBoardInfo(pictureCommand, boardToken);
+        var boardCommand = boardDtoMapper.of(request);
+        var boardInfo = boardService.changeBoardInfo(boardCommand, boardToken);
         var response = boardDtoMapper.of(boardInfo);
         return CommonResponse.success(response);
     }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -29,8 +29,10 @@ public class BoardDto {
     @Setter
     @ToString
     public static class RegisterTagGroupRequest {
-        private String tagGroupName;
-        private String tagValue;
+        // private String tagGroupName;
+        // private String tagValue;
+        private String weather;
+        private List<String> style;
     }
 
     @Getter
@@ -91,14 +93,14 @@ public class BoardDto {
         private final String nickname;
         private final Integer views;
         private final Boolean bookmarked;
-//        private final List<TagGroupInfo> itemOptionGroupList;
+        // private final List<TagGroupInfo> itemOptionGroupList;
     }
 
-//    @Getter
-//    @Builder
-//    @ToString
-//    public static class TagGroupInfo {
-//        private final String tagGroupType;
-//        private final String tagValue;
-//    }
+    // @Getter
+    // @Builder
+    // @ToString
+    // public static class TagGroupInfo {
+    // private final String tagGroupType;
+    // private final String tagValue;
+    // }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -34,6 +34,20 @@ public class BoardDto {
     }
 
     @Getter
+    @Setter
+    @ToString
+    public static class GetPictureRequest {
+        private String weather;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class PictureListResponse {
+        private final List<StyleInfo> styleInfoList;
+    }
+
+    @Getter
     @Builder
     @ToString
     public static class RegisterResponse {
@@ -64,17 +78,27 @@ public class BoardDto {
     @Getter
     @Builder
     @ToString
-    public static class PictureInfo {
-        private final String pictureToken;
-        private final String userToken;
-        private final List<TagGroupInfo> itemOptionGroupList;
+    public static class StyleInfo {
+        private final String style;
+        private final List<PictureDetailInfo> pictureInfoList;
     }
 
     @Getter
     @Builder
     @ToString
-    public static class TagGroupInfo {
-        private final String tagGroupType;
-        private final String tagValue;
+    public static class PictureDetailInfo {
+        private final String filePath;
+        private final String nickname;
+        private final Integer views;
+        private final Boolean bookmarked;
+//        private final List<TagGroupInfo> itemOptionGroupList;
     }
+
+//    @Getter
+//    @Builder
+//    @ToString
+//    public static class TagGroupInfo {
+//        private final String tagGroupType;
+//        private final String tagValue;
+//    }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -1,7 +1,6 @@
 package com.yapp.ios2.fitfty.interfaces.board;
 
 import com.yapp.ios2.fitfty.domain.board.Board.CloudType;
-import com.yapp.ios2.fitfty.domain.board.Picture;
 import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -29,7 +29,7 @@ public class BoardDto {
     @ToString
     public static class RegisterTagGroupRequest {
         private TagGroup.Weather weather;
-        private List<TagGroup.Style> style;
+        private List<String> style;
         private TagGroup.Gender gender;
     }
 

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -1,8 +1,8 @@
 package com.yapp.ios2.fitfty.interfaces.board;
 
-import com.yapp.ios2.fitfty.domain.board.Board;
-import com.yapp.ios2.fitfty.domain.board.Board.WeatherType;
+import com.yapp.ios2.fitfty.domain.board.Board.CloudType;
 import com.yapp.ios2.fitfty.domain.board.Picture;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,19 +20,18 @@ public class BoardDto {
         private String content;
         private Float temperature;
         private String location;
-        private WeatherType weather;
+        private CloudType cloudType;
         private ZonedDateTime photoTakenTime;
-        private List<RegisterTagGroupRequest> tagGroupList;
+        private RegisterTagGroupRequest tagGroup;
     }
 
     @Getter
     @Setter
     @ToString
     public static class RegisterTagGroupRequest {
-        // private String tagGroupName;
-        // private String tagValue;
-        private String weather;
-        private List<String> style;
+        private TagGroup.Weather weather;
+        private List<TagGroup.Style> style;
+        private TagGroup.Gender gender;
     }
 
     @Getter
@@ -56,9 +55,8 @@ public class BoardDto {
         private String content;
         private Float temperature;
         private String location;
-        private WeatherType weather;
+        private CloudType cloudType;
         private ZonedDateTime photoTakenTime;
-        private Picture picture;
     }
 
     @Getter
@@ -66,12 +64,12 @@ public class BoardDto {
     @ToString
     public static class Main {
         private final String boardToken;
-        private final String userToken;
+        private final String nickname;
         private final String filePath;
         private final String content;
         private final String location;
         private final Float temperature;
-        private final Board.WeatherType weather;
+        private final CloudType cloudType;
         private final ZonedDateTime photoTakenTime;
         private final Integer views;
         private final Integer bookmarkCnt;
@@ -93,14 +91,5 @@ public class BoardDto {
         private final String nickname;
         private final Integer views;
         private final Boolean bookmarked;
-        // private final List<TagGroupInfo> itemOptionGroupList;
     }
-
-    // @Getter
-    // @Builder
-    // @ToString
-    // public static class TagGroupInfo {
-    // private final String tagGroupType;
-    // private final String tagValue;
-    // }
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
@@ -3,6 +3,7 @@ package com.yapp.ios2.fitfty.interfaces.board;
 import com.yapp.ios2.fitfty.domain.board.Board;
 import com.yapp.ios2.fitfty.domain.board.BoardInfo;
 import com.yapp.ios2.fitfty.domain.board.BoardCommand;
+import com.yapp.ios2.fitfty.domain.board.PictureInfo;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -27,4 +28,7 @@ public interface BoardDtoMapper {
 
     // retrieve
     BoardDto.Main of(BoardInfo.Main main);
+
+    BoardDto.PictureListResponse of(PictureInfo.Main pictureInfo);
+
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
@@ -17,7 +17,7 @@ public interface BoardDtoMapper {
                         @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss") })
         BoardCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
 
-        BoardCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
+//        BoardCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
 
         @Mappings({ @Mapping(source = "board.picture", target = "picture") })
         BoardDto.RegisterResponse of(Board board);

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
@@ -10,25 +10,25 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 
-@Mapper(
-        componentModel = "spring",
-        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-        unmappedTargetPolicy = ReportingPolicy.ERROR
-)
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface BoardDtoMapper {
-    // register
-    @Mappings({@Mapping(source = "request.tagGroupList", target = "registerTagGroupRequestList"),
-            @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss")})
-    BoardCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
+        // register
+        @Mappings({ @Mapping(source = "request.tagGroupList", target = "registerTagGroupRequestList"),
+                        @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss") })
+        BoardCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
 
-    BoardCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
+        BoardCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
 
-    @Mappings({@Mapping(source = "board.picture", target = "picture")})
-    BoardDto.RegisterResponse of(Board board);
+        @Mappings({ @Mapping(source = "board.picture", target = "picture") })
+        BoardDto.RegisterResponse of(Board board);
 
-    // retrieve
-    BoardDto.Main of(BoardInfo.Main main);
+        // retrieve
+        BoardDto.Main of(BoardInfo.Main main);
 
-    BoardDto.PictureListResponse of(PictureInfo.Main pictureInfo);
+        BoardDto.PictureListResponse of(PictureInfo.Main pictureInfo);
+
+        BoardDto.StyleInfo of(PictureInfo.StyleInfo styleInfo);
+
+        BoardDto.PictureDetailInfo of(PictureInfo.PictureDetailInfo pictureDetailInfo);
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDtoMapper.java
@@ -12,23 +12,20 @@ import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, unmappedTargetPolicy = ReportingPolicy.ERROR)
 public interface BoardDtoMapper {
-        // register
-        @Mappings({ @Mapping(source = "request.tagGroupList", target = "registerTagGroupRequestList"),
-                        @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss") })
-        BoardCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
+    // register
+    @Mappings({@Mapping(source = "request.tagGroup", target = "registerTagGroupRequest"),
+            @Mapping(source = "request.photoTakenTime", target = "photoTakenTime", dateFormat = "yyyy-MM-dd HH:mm:ss")})
+    BoardCommand.RegisterBoardRequest of(BoardDto.RegisterBoardRequest request);
 
-//        BoardCommand.RegisterTagGroupRequest of(BoardDto.RegisterTagGroupRequest request);
+    BoardDto.RegisterResponse of(Board board);
 
-        @Mappings({ @Mapping(source = "board.picture", target = "picture") })
-        BoardDto.RegisterResponse of(Board board);
+    // retrieve
+    BoardDto.Main of(BoardInfo.Main main);
 
-        // retrieve
-        BoardDto.Main of(BoardInfo.Main main);
+    BoardDto.PictureListResponse of(PictureInfo.Main pictureInfo);
 
-        BoardDto.PictureListResponse of(PictureInfo.Main pictureInfo);
+    BoardDto.StyleInfo of(PictureInfo.StyleInfo styleInfo);
 
-        BoardDto.StyleInfo of(PictureInfo.StyleInfo styleInfo);
-
-        BoardDto.PictureDetailInfo of(PictureInfo.PictureDetailInfo pictureDetailInfo);
+    BoardDto.PictureDetailInfo of(PictureInfo.PictureDetailInfo pictureDetailInfo);
 
 }

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/StyleController.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/StyleController.java
@@ -1,0 +1,30 @@
+package com.yapp.ios2.fitfty.interfaces.board;
+
+import com.yapp.ios2.fitfty.domain.board.BoardService;
+import com.yapp.ios2.fitfty.global.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.yapp.ios2.fitfty.global.util.Constants.API_PREFIX;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(API_PREFIX + "/styles")
+public class StyleController {
+    private final BoardService boardService;
+    private final BoardDtoMapper boardDtoMapper;
+
+    @GetMapping()
+    public CommonResponse getPictureList(@RequestBody @Valid BoardDto.GetPictureRequest request) {
+        var board = boardService.getPictureList(request);
+        var response = boardDtoMapper.of(board);
+        return CommonResponse.success(response);
+    }
+}


### PR DESCRIPTION
### 📙 작업 내역

- [x] 사용자가 관심등록한 스타일 목록별 5장씩 랜덤하게 반환해주는 api 생성
- [x] `BoardReadeImpl.java`에서 확인 가능
- [x] 강수량, 태그 enum 클래스 생성 및 적용
- [x] 성별태그 추가
- [x] 게시글 조회 시 유저토큰 대신 유저 닉네임 반환코드 추가
- [x] 게시글 변경 리스폰스 no content로 변경


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트



### 📝 리뷰 노트

- 필터링 기능 및 기획 변경된 내용은 프론트와 협의 후 다시 변경 작업 시작하겠습니다
