### PR TITLE
[Ios2-157] 게시글 조회api 리스폰스 변경

### DIFF
--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/Board.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/Board.java
@@ -1,6 +1,7 @@
 package com.yapp.ios2.fitfty.domain.board;
 
 import com.yapp.ios2.fitfty.domain.AbstractEntity;
+import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import com.yapp.ios2.fitfty.global.exception.InvalidParamException;
 import com.yapp.ios2.fitfty.global.util.TokenGenerator;
 import lombok.Builder;
@@ -94,6 +95,11 @@ public class Board extends AbstractEntity {
 
     public void decreaseBookmarkCnt() {
         this.bookmarkCnt -= 1;
+    }
+
+    public TagGroup getTagGroup() {
+        return this.getPicture()
+                .getTagGroup();
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfo.java
@@ -1,6 +1,5 @@
 package com.yapp.ios2.fitfty.domain.board;
 
-import com.yapp.ios2.fitfty.domain.tag.TagGroup;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -16,16 +15,19 @@ public class BoardInfo {
     public static class Main {
         private final Long boardId;
         private final String boardToken;
+        private final String userToken;
         private final String nickname;
         private final String profilePictureUrl;
         private final String filePath;
         private final String content;
+        private final TagGroupInfo tagGroupInfo;
         private final String location;
         private final Float temperature;
         private final Board.CloudType cloudType;
         private final ZonedDateTime photoTakenTime;
         private final Integer views;
         private final Integer bookmarkCnt;
+        private final Boolean bookmarked;
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardInfoMapper.java
@@ -13,10 +13,11 @@ public interface BoardInfoMapper {
     @Mappings({
             @Mapping(source = "board.id", target = "boardId"),
             @Mapping(expression = "java(board.getPicture().getFilePath())", target = "filePath"),
+            @Mapping(expression = "java(user.getUserToken())", target = "userToken"),
             @Mapping(expression = "java(user.getNickname())", target = "nickname"),
             @Mapping(expression = "java(user.getProfilePictureUrl())", target = "profilePictureUrl")
     })
-    BoardInfo.Main of(Board board, User user);
+    BoardInfo.Main of(Board board, User user, BoardInfo.TagGroupInfo tagGroupInfo, Boolean bookmarked);
 
     BoardInfo.TagGroupInfo of(TagGroup tagGroup);
 

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/BoardServiceImpl.java
@@ -49,9 +49,12 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public BoardInfo.Main retrieveBoardInfo(String boardToken) {
         var board = boardReader.getBoard(boardToken);
-        var user = userReader.findFirstByUserToken(board.getUserToken());
+        var userToken = board.getUserToken();
+        var user = userReader.findFirstByUserToken(userToken);
+        var tagGroupInfo = boardInfoMapper.of(board.getTagGroup());
+        Boolean bookmarked = userService.getBookmark(userToken).contains(boardToken);
         board.increaseViews();
-        return boardInfoMapper.of(board, user);
+        return boardInfoMapper.of(board, user, tagGroupInfo, bookmarked);
     }
 
     @Override

--- a/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/board/PictureInfo.java
@@ -21,14 +21,18 @@ public class PictureInfo {
     public static class PictureDetailInfo {
         private final String filePath;
         private final String boardToken;
+        private final String userToken;
         private final String nickname;
         private final String profilePictureUrl;
         private final Integer views;
         private final Boolean bookmarked;
 
-        public PictureDetailInfo(String filePath, String boardToken, Integer views, String nickname, String profilePictureUrl, Boolean bookmarked) {
+        public PictureDetailInfo(String filePath, String boardToken, Integer views,
+                                 String userToken, String nickname, String profilePictureUrl,
+                                 Boolean bookmarked) {
             this.filePath = filePath;
             this.boardToken = boardToken;
+            this.userToken = userToken;
             this.nickname = nickname;
             this.profilePictureUrl = profilePictureUrl;
             this.views = views;

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardReaderImpl.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/board/BoardReaderImpl.java
@@ -82,6 +82,7 @@ public class BoardReaderImpl implements BoardReader {
                     return new PictureInfo.PictureDetailInfo(picture.getFilePath(),
                                                              board.getBoardToken(),
                                                              board.getViews(),
+                                                             user.getUserToken(),
                                                              user.getNickname(),
                                                              user.getProfilePictureUrl(),
                                                              bookmarked);

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -104,6 +104,7 @@ public class BoardDto {
     public static class PictureDetailInfo {
         private final String filePath;
         private final String boardToken;
+        private final String userToken;
         private final String nickname;
         private final String profilePictureUrl;
         private final Integer views;

--- a/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
+++ b/src/main/java/com/yapp/ios2/fitfty/interfaces/board/BoardDto.java
@@ -74,16 +74,28 @@ public class BoardDto {
     @ToString
     public static class Main {
         private final String boardToken;
+        private final String userToken;
         private final String nickname;
         private final String profilePictureUrl;
         private final String filePath;
         private final String content;
+        private final TagGroupInfo tagGroupInfo;
         private final String location;
         private final Float temperature;
         private final CloudType cloudType;
         private final ZonedDateTime photoTakenTime;
         private final Integer views;
         private final Integer bookmarkCnt;
+        private final Boolean bookmarked;
+    }
+
+    @Getter
+    @Builder
+    @ToString
+    public static class TagGroupInfo {
+        private final String weather;
+        private final List<String> style;
+        private final String gender;
     }
 
     @Getter


### PR DESCRIPTION
### 📙 작업 내역

- [x] 게시글 조회 api 리스폰스에 태그그룹, 유저토큰, 북마크 여부 추가
- [x] 메인페이지 코디추천목록 리스폰스에 작성자 userToken 추가


### 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트



### 📝 리뷰 노트

- 프론트 요청사항 반영하여 리스폰스 형태 수정
