### PR TITLE
반환 값에 Role 추가, Apple Login Email 없는 경우 Token parsing 으로 대응하도록 변경

### DIFF
--- a/src/main/java/com/yapp/ios2/fitfty/domain/user/UserCommand.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/user/UserCommand.java
@@ -101,6 +101,10 @@ public class UserCommand {
         String userEmail;
         String userName;
         String identityToken;
+
+        public void setUserEmail(String email) {
+            this.userEmail = email;
+        }
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/domain/user/UserInfo.java
+++ b/src/main/java/com/yapp/ios2/fitfty/domain/user/UserInfo.java
@@ -33,6 +33,7 @@ public class UserInfo {
         private String nickname;
         private Gender gender;
         private String birthday;
+        private String role;
     }
 
     @Getter

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/user/OAuth/ApplePublicKeyResponse.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/user/OAuth/ApplePublicKeyResponse.java
@@ -1,0 +1,49 @@
+package com.yapp.ios2.fitfty.infrastructure.user.OAuth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApplePublicKeyResponse {
+    // 애플은 3개의 공개키를 줌
+    @JsonProperty("keys")
+    public List<MaterialsOfApplePublicKey> keys;
+
+    // 3개의 공개키 중 사용할 키 찾기
+    public Optional<MaterialsOfApplePublicKey> getMatchedKeyBy(Object kid, Object alg) {
+        return this.keys.stream()
+                .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
+                .findFirst();
+    }
+
+    static public ApplePublicKeyResponse getApplePublicKeys() {
+        // URI 준비
+        URI url = URI.create("https://appleid.apple.com/auth/keys");
+
+        // Http Request 발싸
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity response = restTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ApplePublicKeyResponse result = null;
+        try {
+            result = objectMapper.readValue(response.getBody().toString(),ApplePublicKeyResponse.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/yapp/ios2/fitfty/infrastructure/user/OAuth/MaterialsOfApplePublicKey.java
+++ b/src/main/java/com/yapp/ios2/fitfty/infrastructure/user/OAuth/MaterialsOfApplePublicKey.java
@@ -1,0 +1,17 @@
+package com.yapp.ios2.fitfty.infrastructure.user.OAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MaterialsOfApplePublicKey {
+    String kty;
+    String kid;
+    String use;
+    String alg;
+    String n;
+    String e;
+}


### PR DESCRIPTION
### 📙 작업 내역

> 구현 내용 및 작업 했던 내역, 변경 사항을 포함합니다.

- [x] /users/privacy 반환 값에 Role 추가 
- [x] Apple Login Email 없는 경우 Token parsing 으로 대응하도록 변경


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트



### 📝 리뷰 노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있다면 PR 리뷰를 돕기 위해 서술합니다. 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에도 같이 작성해주면 좋습니다.

- 내용기재
